### PR TITLE
feat(run): add a run-method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Fix: only initialize LuaLanes if not initialized already
 - Added: `io_popen` now also has the `lines` iterator (except for Puc Rio Lua 5.1
   where it will not work due to c-boundary issues)
+- Added: `run` method, to simply run and wait for an async result while not blocking
+  (this also is the default action when calling on the module table).
 
 ### Version 0.3, released 4-Jul-2016
 

--- a/doc_topics/01-introduction.md
+++ b/doc_topics/01-introduction.md
@@ -4,7 +4,7 @@ Copas-Async is a Copas-friendly true asynchronous threads, powered by Lua Lanes.
 
 **This is alpha software, use at your own peril!**
 
-1.1 Installing
+## Installing
 
     luarocks install copas-async
 


### PR DESCRIPTION
run will execute a long running task in the background and will
wait for the results. It is also set up as the default method,
executed when calling on the module table itself.