### PR TITLE
feat(async): [breaking] align future API with copas.future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Breaking: `future:get()` now returns pcall-style: `true` + results on success,
   `false` + errmsg on failure. Previously it returned the results directly and
   raised on error.
+- Deps: bump Copas to 4.10
 - Added: task errors are now captured and returned via `get()`/`try()` instead
   of being silently lost.
 - Added: `future:try()` now returns a 3-state status constant instead of a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,27 @@
   `luarocks install copas-async`
 
 
+### Version 2.0.0, released (unreleased)
+
+- Breaking: The future interface now matches the Copas future interface.
+- Breaking: `future:get()` now returns pcall-style: `true` + results on success,
+  `false` + errmsg on failure. Previously it returned the results directly and
+  raised on error.
+- Added: task errors are now captured and returned via `get()`/`try()` instead
+  of being silently lost.
+- Added: `future:try()` now returns a 3-state status constant instead of a
+  plain boolean. Returns `async.PENDING` (false) when still running,
+  `async.SUCCESS` (true) + results on success, or `async.ERROR` ("error") +
+  errmsg on failure.
+- Added: `future:cancel()` to cancel a pending task. The Copas side is cancelled
+  immediately; any coroutines blocked in `get()` are released with
+  `false + "cancelled"`. The underlying Lanes thread is soft-cancelled and
+  force-killed after `async.cancel_timeout` seconds (default 5) if it has not
+  yet stopped (e.g. when blocked in a C call).
+- Added: `async.cancel_timeout` field to control the force-kill delay.
+- Added: multiple coroutines may now call `future:get()` concurrently; all are
+  released when the result arrives (previously concurrent access raised an error).
+
 ### Version 1.0.0, released 26-Jun-2023
 
 - Breaking: the `os_execute` return codes are no longer normalized to Lua 5.3 output

--- a/copas-async-scm-1.rockspec
+++ b/copas-async-scm-1.rockspec
@@ -26,7 +26,7 @@ description = {
 dependencies = {
    "lua >= 5.1",
    "lanes >= 3.10.0",
-   "copas >= 2.0.2",
+   "copas >= 4.10.0",
 }
 
 build = {

--- a/example/example-popen.lua
+++ b/example/example-popen.lua
@@ -2,17 +2,10 @@
 local copas = require("copas")
 local async = require("copas.async")
 
--- local fd = io.popen("for i in `seq 5`; do echo 'thread B says '$i; sleep 1; done; exit 99")
--- while true do
---   local d, e = fd:read("*l")
---   print("got:",d,e)
---   if d == nil then
---     return
---   end
--- end
 
 copas(function()
 
+  -- Adds a Copas based coroutine (NOT running in a Lane)
   copas.addthread(function()
     for i = 1, 10 do
        print("coroutine A says ", i*2)
@@ -22,41 +15,47 @@ copas(function()
   end)
 
 
-  -- copas.addthread(function()
-  --   print("Result B",async.os_execute("for i in `seq 5`; do echo 'thread B says '$i; sleep 1; done; exit 99"))
-  --   print("DONE B")
-  -- end)
+  -- Runs an os.execute command in a lane, blocking the current coroutine, but letting other coroutines run.
+  copas.addthread(function()
+    print("Result B",async.os_execute("for i in `seq 5`; do echo 'thread    B says '$i; sleep 1; done; exit 99"))
+    print("DONE B")
+  end)
 
+
+  -- Runs a command async through io.popen, reads input line-by-line (the wait implemented Lua-side)
   copas.addthread(function()
     local fd = async.io_popen("ls /")
     while true do
       local d, e = fd:read("*l")
-      print("got:",d,e)
+      print("coroutine C got:",d,e)
       if d == nil then
         break
       end
-      require("socket").sleep(0.5)
+      copas.sleep(0.5)
     end
     print("DONE C")
   end)
 
+  -- Runs a command async through io.popen, reads input line-by-line (the wait in the shell command)
+  copas.addthread(function()
+    local fd = async.io_popen("for i in `seq 5`; do echo 'says '$i; sleep 1; done; exit 99")
+    print"D is open"
+    while true do
+      local data, err = fd:read()
 
-  -- copas.addthread(function()
-  --   local fd = async.io_popen("for i in `seq 5`; do echo 'thread B says '$i; sleep 1; done; exit 99")
-  --   print"A is open"
-  --   require("socket").sleep(4)
-  --   -- for i = 1, 10 do
-  --   while true do
-  --     local data, err = fd:read()
-
-  --     print("received ",data, err)
-  --     if err then break end
-  --     if data == nil then break end
-  --     --copas.sleep(1)
-  --   end
-  --   print("closing", fd:close())
-  --   print("DONE A")
-  -- end)
+      print("thread    D ",data, err)
+      if err then
+        print("thread    D encountered error: ", err)
+        break
+      end
+      if data == nil then
+        print("thread    D reached EOF")
+        break
+      end
+    end
+    print("closing D", fd:close())
+    print("DONE D")
+  end)
 
 end)
 

--- a/example/example.lua
+++ b/example/example.lua
@@ -28,8 +28,8 @@ copas.addthread(function()
    print("coroutine B will wait for thread value...")
    val = future:get()
    print("coroutine B got value from thread:", val)
-   local ret, typ, cod = async.os_execute("sleep 2; exit 12")
-   print("coroutine B slept a bit: ", ret, typ, cod)
+   local success, ret, typ, cod = async.os_execute("sleep 2; exit 12")
+   print("coroutine B slept a bit: ", success, ret, typ, cod)
    print("DONE B")
 end)
 
@@ -37,27 +37,26 @@ copas.loop()
 
 --[[ produces:
 
-    coroutine A says 1
-    thread says hello 1
-    coroutine A says 2
-    coroutine B will try to get thread value
-    coroutine B didn't get a value because thread is not done!
-    coroutine B will wait for thread value...
-    thread says hello 2
-    coroutine A says 3
-    thread says hello 3
-    coroutine A says 4
-    thread says hello 4
-    coroutine A says 5
-    thread says hello 5
-    coroutine A says 6
-    coroutine B got value from thread:123
-    coroutine A says 7
-    coroutine A says 8
-    coroutine B slept a bit:   nil    exit    12
-    DONE B
-    coroutine A says 9
-    coroutine A says 10
-    DONE A
+      thread says hello 1
+      coroutine A says        2
+      thread says hello 2
+      coroutine B will try to get thread value:
+      coroutine B didn't get a value because thread is not done!
+      coroutine B will wait for thread value...
+      coroutine A says        3
+      thread says hello 3
+      coroutine A says        4
+      thread says hello 4
+      coroutine A says        5
+      thread says hello 5
+      coroutine A says        6
+      coroutine B got value from thread:      true
+      coroutine A says        7
+      coroutine A says        8
+      coroutine B slept a bit:        true    nil     exit    12
+      DONE B
+      coroutine A says        9
+      coroutine A says        10
+      DONE A
 
 ]]

--- a/spec/async_spec.lua
+++ b/spec/async_spec.lua
@@ -89,6 +89,87 @@ describe("copas-async", function()
       end)
 
 
+      it("cancel() while pending returns true", function()
+         local result = {}
+         copas(function()
+            local future = async.addthread(assert(load([[
+               local socket = require "socket"
+               socket.sleep(5)
+               return "hello"
+            ]])))
+            copas.sleep(0.5) -- let the thread start
+            result.cancel = future:cancel()
+            result.try    = { future:try() }
+            result.get    = { future:get() }
+            done()
+         end)
+         assert.is_true(result.cancel)
+         assert.same({ async.ERROR, "cancelled" }, result.try)
+         assert.same({ false, "cancelled" }, result.get)
+      end)
+
+
+      it("cancel() after done returns false", function()
+         local result = {}
+         copas(function()
+            local future = async.addthread(assert(load([[
+               return "hello"
+            ]])))
+            copas.sleep(1) -- let the thread finish
+            result.cancel = future:cancel()
+            result.get    = { future:get() }
+            done()
+         end)
+         assert.is_false(result.cancel)
+         assert.same({ true, "hello" }, result.get)
+      end)
+
+
+      it("cancel() force-kills the lane after cancel_timeout", function()
+         settimeout(5)
+         local saved_timeout = async.cancel_timeout
+         finally(function()
+            async.cancel_timeout = saved_timeout
+         end)
+         async.cancel_timeout = 1  -- speed up the test
+
+         local lane_status
+         copas(function()
+            local future = async.addthread(assert(load([[
+               local socket = require "socket"
+               socket.sleep(10)  -- long C-level block, soft cancel won't stop it
+            ]])))
+            copas.sleep(0.5)
+            future:cancel()
+            copas.sleep(1.5)  -- wait past cancel_timeout
+            lane_status = future.lane.status
+            done()
+         end)
+         assert.are_equal("cancelled", lane_status)
+      end)
+
+
+      it("cancel() releases a coroutine blocked in get()", function()
+         local result = {}
+         copas(function()
+            local future = async.addthread(assert(load([[
+               local socket = require "socket"
+               socket.sleep(5)
+               return "hello"
+            ]])))
+            copas.addthread(function()
+               result.get = { future:get() }
+            end)
+            copas.sleep(0.5) -- ensure the get() coroutine is already waiting
+            result.cancel = future:cancel()
+            copas.sleep(0.5) -- let the woken coroutine run
+            done()
+         end)
+         assert.is_true(result.cancel)
+         assert.same({ false, "cancelled" }, result.get)
+      end)
+
+
       it("concurrent get() is allowed", function()
          local result = {}
          copas(function()

--- a/spec/async_spec.lua
+++ b/spec/async_spec.lua
@@ -35,7 +35,7 @@ describe("copas-async", function()
             result.duration = socket.gettime() - starttime
             done()
          end)
-         assert.same({"hello", "world"}, result.returned)
+         assert.same({true, "hello", "world"}, result.returned)
          assert.near(3, 0.1, result.duration)
       end)
 
@@ -50,7 +50,7 @@ describe("copas-async", function()
             result = { future:get() }
             done()
          end)
-         assert.same({"hello", "world"}, result)
+         assert.same({true, "hello", "world"}, result)
       end)
 
 
@@ -69,7 +69,7 @@ describe("copas-async", function()
             end
             done()
          end)
-         assert.same({ {false}, {false}, {false}, {true, "hello", "world"}}, result)
+         assert.same({ {async.PENDING}, {async.PENDING}, {async.PENDING}, {async.SUCCESS, "hello", "world"}}, result)
       end)
 
 
@@ -83,33 +83,32 @@ describe("copas-async", function()
             result = { future:try() }
             done()
          end)
-         assert.same({true, "hello", "world"}, result)
+         assert.same({async.SUCCESS, "hello", "world"}, result)
       end)
 
 
-      it("concurrent access to future errors", function()
+      it("concurrent get() is allowed", function()
          local result = {}
          copas(function()
             local future = async.addthread(assert(load([[
                local socket = require "socket"
-               socket.sleep(3)
+               socket.sleep(1)
                return "hello", "world"
             ]])))
             copas.addthread(function()
-               result.success = { future:get() }
-               done()
+               result[1] = { future:get() }
             end)
-            copas.sleep(0.1) -- ensure the 'get' is in progress
-            copas.addthread(function() -- test future:try
-               result.try = { pcall(future.try, future) }
+            copas.sleep(0.1) -- ensure the first get() is already waiting
+            copas.addthread(function()
+               result[2] = { future:get() }
             end)
-            copas.addthread(function() -- test future:get
-               result.get = { pcall(future.get, future) }
-            end)
+            while not result[1] or not result[2] do
+               copas.sleep(0.1)
+            end
+            done()
          end)
-         assert(result.get[2]:match("concurrent access to future"))
-         assert(result.try[2]:match("concurrent access to future"))
-         assert.same({"hello", "world"}, result.success)
+         assert.same({true, "hello", "world"}, result[1])
+         assert.same({true, "hello", "world"}, result[2])
       end)
 
    end) -- futures
@@ -119,11 +118,12 @@ describe("copas-async", function()
    describe("os_execute:", function()
 
       it("returns the exit code on success", function()
-         local r, t, c
+         local ok, r, t, c
          copas(function()
-            r, t, c = async.os_execute("sleep 1")
+            ok, r, t, c = async.os_execute("sleep 1")
             done()
          end)
+         assert.same(true, ok) -- pcall-style ok flag
          if _VERSION == "Lua 5.1" then
             assert(r == 0 or r == true, "expected the result code to be 0 or 'true'")
          else
@@ -135,11 +135,12 @@ describe("copas-async", function()
 
 
       it("returns the exit code on failure", function()
-         local r, t, c
+         local ok, r, t, c
          copas(function()
-            r, t, c = async.os_execute("sleep 1; exit 123")
+            ok, r, t, c = async.os_execute("sleep 1; exit 123")
             done()
          end)
+         assert.same(true, ok) -- pcall-style ok flag (task ran; os exit code is in r)
          if _VERSION == "Lua 5.1" then
             assert.not_equal(0, r)
          else

--- a/spec/async_spec.lua
+++ b/spec/async_spec.lua
@@ -8,12 +8,14 @@ describe("copas-async", function()
    local copas, done, settimeout, async, socket
 
    before_each(function()
+      _G._TEST = true
       copas, done, settimeout = copastest(defTimeout)
       async = require "copas.async"
       socket = require "socket"
    end)
 
    after_each(function()
+      _G._TEST = nil
       done()
    end)
 

--- a/src/copas/async.lua
+++ b/src/copas/async.lua
@@ -53,6 +53,13 @@ local async = {
    SUCCESS = copas.future.SUCCESS,
    PENDING = copas.future.PENDING,
    ERROR   = copas.future.ERROR,
+
+   --- Timeout in seconds before a cancelled lane is force-killed.
+   -- After `future:cancel()` the underlying Lanes thread is soft-cancelled first.
+   -- If it is still running after this many seconds it will be hard-killed
+   -- (`pthread_cancel`). Set to `math.huge` to never force-kill.
+   -- @field async.cancel_timeout
+   cancel_timeout = 5,
 }
 
 local whost, wport
@@ -240,9 +247,23 @@ local function new_future(ch, ch_id, lane)
    --- Cancels the future if the task has not yet completed.
    -- Returns true if cancelled, false if already done.
    -- Any coroutines blocked in `get()` will be released and return false+"cancelled".
+   --
+   -- The underlying Lanes thread is soft-cancelled immediately. If it is still running
+   -- after `async.cancel_timeout` seconds (e.g. blocked inside a C function such as
+   -- `socket.sleep` or `os.execute`), it will be force-killed. The Copas side is
+   -- always cancelled immediately; any result produced by the thread afterwards is
+   -- discarded.
    -- @function future:cancel
    -- @return true if cancelled, false if already done
    function fut:cancel()
+      if not self.results then
+         -- check if the result arrived on the Linda without anyone polling yet
+         local key, value = ch:receive(0, ch_id)
+         if key then
+            self.results = value
+            self.sema:give(self.sema:get_wait())
+         end
+      end
       if self.results then
          return false  -- already done (or already cancelled)
       end
@@ -253,7 +274,18 @@ local function new_future(ch, ch_id, lane)
       end
       self.sema:give(self.sema:get_wait())
       if self.lane then
-         self.lane:cancel(0, true)
+         self.lane:cancel()  -- soft cancel; best-effort, the lane may not honour it
+         -- schedule a hard kill after cancel_timeout in case soft cancel was ignored
+         -- (e.g. the thread is blocked inside a C function like socket.sleep)
+         local lane = self.lane
+         copas.timer.new({
+            delay = async.cancel_timeout,
+            callback = function()
+               if lane.status == "running" or lane.status == "waiting" then
+                  pcall(lane.cancel, lane, 0, true)
+               end
+            end,
+         })
       end
       return true
    end

--- a/src/copas/async.lua
+++ b/src/copas/async.lua
@@ -57,6 +57,7 @@ local async = {
 
 local whost, wport
 local add_waiting_coro
+local remove_waiting_coro
 
 do -- wakeup server
    local waiting = {}
@@ -65,7 +66,7 @@ do -- wakeup server
    whost, wport = wskt:getsockname()
    wport = tonumber(wport)
 
-   local function remove_waiting_coro(id)
+   remove_waiting_coro = function(id)
       local coro = waiting[id]
       waiting[id] = nil
       if not next(waiting) then
@@ -133,11 +134,13 @@ end
 -- @type future
 -- @tparam linda ch the linda to operate on
 -- @param ch_id, the linda key to look for ("done", "data", etc.)
-local function new_future(ch, ch_id)
+-- @param lane the Lanes thread to cancel when `future:cancel()` is called
+local function new_future(ch, ch_id, lane)
    local fut = {
       results = nil, -- packed results: first value is ok-flag (true/false), then the actual values
       sema = copas.semaphore.new(9999, 0, math.huge),
       waiting = false, -- true once a coroutine has registered with the wakeup server
+      lane = lane,
    }
 
    --- Obtains the result value of the async thread function if it is already available,
@@ -234,6 +237,27 @@ local function new_future(ch, ch_id)
       return unpack(self.results)
    end
 
+   --- Cancels the future if the task has not yet completed.
+   -- Returns true if cancelled, false if already done.
+   -- Any coroutines blocked in `get()` will be released and return false+"cancelled".
+   -- @function future:cancel
+   -- @return true if cancelled, false if already done
+   function fut:cancel()
+      if self.results then
+         return false  -- already done (or already cancelled)
+      end
+      self.results = pack(false, "cancelled")
+      local coro = remove_waiting_coro(tostring(ch))
+      if coro then
+         copas.wakeup(coro)
+      end
+      self.sema:give(self.sema:get_wait())
+      if self.lane then
+         self.lane:cancel(0, true)
+      end
+      return true
+   end
+
    setmetatable(fut, { __call = function(self, ...) return self:get(...) end })
    return fut
 end
@@ -252,7 +276,7 @@ end
 function async.addthread(fn)
    local ch = lanes.linda()
 
-   lanes.gen("*", function()
+   local lane = lanes.gen("*", function()
       local results
       local ok, err = pcall(function()
          results = pack(true, fn())
@@ -263,7 +287,7 @@ function async.addthread(fn)
       awake_future(ch, "done", unpack(results, 1, results.n))
    end)()
 
-   return new_future(ch, "done")
+   return new_future(ch, "done", lane)
 end
 
 

--- a/src/copas/async.lua
+++ b/src/copas/async.lua
@@ -143,9 +143,31 @@ local function new_future(ch, ch_id)
    --- Obtains the result value of the async thread function if it is already available,
    -- or returns `async.PENDING` if it is still running. This function always returns immediately.
    -- @function future:try
-   -- @return `async.PENDING` (false) when still running;
-   --         `async.SUCCESS` (true) + results when complete;
-   --         `async.ERROR` ("error") + errmsg when the task failed.
+   -- @return `async.PENDING` (false) when still running
+   -- @return `async.SUCCESS` (true) + results when complete
+   -- @return `async.ERROR` ("error") + errmsg when the task failed
+   -- @usage
+   -- local msg = "hello"
+   -- copas(function()
+   --    -- schedule a thread using LuaLanes
+   --    local future = async.addthread(function()
+   --       os.execute("for i in seq 5; do echo 'thread says "..msg.." '$i; sleep 1; done")
+   --       return 123
+   --    end)
+   --
+   --    -- loop to wait for result
+   --    local done, result
+   --    while not done do
+   --       copas.sleep(0.1)
+   --       done, result = future:try()
+   --    end
+   --
+   --    if done == async.ERROR then
+   --       print("oops... something went wrong: " .. result)
+   --    else
+   --       assert(123 == result, "expected exit code 123")
+   --    end
+   -- end)
    function fut:try()
       if not self.results then
          local key, value = ch:receive(0, ch_id)

--- a/src/copas/async.lua
+++ b/src/copas/async.lua
@@ -32,6 +32,18 @@ local pack, unpack do -- pack/unpack to create/honour the .n field for nil-safet
    local _unpack = _G.table.unpack or _G.unpack
    function pack (...) return { n = select('#', ...), ...} end
    function unpack(t, i, j) return _unpack(t, i or 1, j or t.n or #t) end
+
+   if _G._TEST then
+      -- In test environments (e.g. busted), _G.unpack may be overridden with a
+      -- non-transferable function. This pure recursive implementation has no external
+      -- upvalues and is safe for Lanes transfer on any Lua version.
+      function unpack(t, i, j)
+         i = i or 1
+         j = j or t.n or #t
+         if i > j then return end
+         return t[i], unpack(t, i + 1, j)
+      end
+   end
 end
 
 

--- a/src/copas/async.lua
+++ b/src/copas/async.lua
@@ -20,8 +20,6 @@
 --
 -- local ok, err = async(sometask)
 
-local async = {}
-
 local lanes = require("lanes")
 local copas = require("copas")
 local socket = require("socket")
@@ -36,6 +34,14 @@ local pack, unpack do -- pack/unpack to create/honour the .n field for nil-safet
    function unpack(t, i, j) return _unpack(t, i or 1, j or t.n or #t) end
 end
 
+
+-- Module table
+local async = {
+   -- Status constants (matching copas.future)
+   SUCCESS = copas.future.SUCCESS,
+   PENDING = copas.future.PENDING,
+   ERROR   = copas.future.ERROR,
+}
 
 local whost, wport
 local add_waiting_coro
@@ -97,7 +103,7 @@ end
 -- The wakeup server (in the copas environment), will find the appropriate coroutine and resume it.
 -- @param ch the Lanes Linda object
 -- @param ch_id "done", "data", "result", etc.
--- @param ... the data to be packed and send over the linda
+-- @param ... the data to be packed and send over the linda (first value is the ok flag)
 -- @return nothing
 local function awake_future(ch, ch_id, ...)
    local socket = require("socket")
@@ -116,59 +122,44 @@ end
 -- @tparam linda ch the linda to operate on
 -- @param ch_id, the linda key to look for ("done", "data", etc.)
 local function new_future(ch, ch_id)
-   local future = {
-      res = nil,     -- will hold the packed results of the function call
-      getting = nil, -- lock; to prevent concurrent access
-      dead = false,  -- if truthy, the function is done
+   local fut = {
+      results = nil, -- packed results: first value is ok-flag (true/false), then the actual values
+      sema = copas.semaphore.new(9999, 0, math.huge),
+      waiting = false, -- true once a coroutine has registered with the wakeup server
    }
 
-
-
    --- Obtains the result value of the async thread function if it is already available,
-   -- or returns `false` if it is still running. This function always returns immediately.
+   -- or returns `async.PENDING` if it is still running. This function always returns immediately.
    -- @function future:try
-   -- @return `true + ...` (the async function results) when complete, or `false` if not yet available
-   -- @usage
-   -- local msg = "hello"
-   -- copas(function()
-   --    -- schedule a thread using LuaLanes
-   --    local future = async.addthread(function()
-   --       os.execute("for i in seq 5; do echo 'thread says "..msg.." '$i; sleep 1; done")
-   --       return 123
-   --    end)
-   --
-   --    -- loop to wait for result
-   --    local done, result
-   --    while not done do
-   --       copas.sleep(0.1)
-   --       done, result = future:try()
-   --    end
-   --
-   --    assert(123 == future(), "expected exit code 123")
-   -- end)
-   future.try = function()
-      assert(not future.getting, "concurrent access to future")
-
-      if not future.res then
+   -- @return `async.PENDING` (false) when still running;
+   --         `async.SUCCESS` (true) + results when complete;
+   --         `async.ERROR` ("error") + errmsg when the task failed.
+   function fut:try()
+      if not self.results then
          local key, value = ch:receive(0, ch_id)
          if key then
-            future.res = value
-            future.dead = true
+            self.results = value
+            self.sema:give(self.sema:get_wait())
          end
       end
 
-      if future.res then
-         return future.dead, unpack(future.res)
+      if not self.results then
+         return async.PENDING
       end
-      return future.dead
+      if self.results[1] then
+         return async.SUCCESS, unpack(self.results, 2)
+      else
+         return async.ERROR, self.results[2]
+      end
    end
 
    --- Waits until the async thread finishes (without locking other Copas coroutines) and
    -- obtains the result values of the async thread function.
    --
    -- Calling on the future object is a shortcut to this `get` method.
+   -- Multiple coroutines may call `get` concurrently; all will be released when the result arrives.
    -- @function future:get
-   -- @return ... the async function results
+   -- @return like pcall: true + results on success, false + errmsg on error
    -- @usage
    -- local msg = "hello"
    -- copas(function()
@@ -180,31 +171,37 @@ local function new_future(ch, ch_id)
    --
    --    -- The following will wait for the thread to complete (5 secs)
    --    -- Note: calling `future()` is the same as `future:get()`
-   --    assert(123 == future(), "expected exit code 123")
+   --    local ok, result = future()
+   --    assert(ok and 123 == result, "expected exit code 123")
    -- end)
-   future.get = function()
-      future.getting = assert(not future.getting, "concurrent access to future")
-
-      if not future.dead then
-         local key, value = ch:receive(0, ch_id)
-         while not key do
-            add_waiting_coro(tostring(ch), coroutine.running())
-            copas.sleep(-1)
-            key, value = ch:receive(0, ch_id)
+   function fut:get()
+      if not self.results then
+         if not self.waiting then
+            -- First caller: do the actual waiting via the wakeup server mechanism
+            self.waiting = true
+            local key, value = ch:receive(0, ch_id)
+            if key then
+               self.results = value
+            else
+               add_waiting_coro(tostring(ch), coroutine.running())
+               copas.pauseforever()
+               -- try() may have already stored the result while we were sleeping
+               if not self.results then
+                  key, value = ch:receive(0, ch_id)
+                  if key then self.results = value end
+               end
+            end
+            self.sema:give(self.sema:get_wait()) -- release any concurrent waiters
+         else
+            -- Subsequent callers: wait for the first caller to receive and release
+            self.sema:take(1, math.huge)
          end
-         if key then
-            future.res = value
-         end
-         future.dead = true
       end
-
-      future.getting = false
-      if future.res then
-         return unpack(future.res)
-      end
+      return unpack(self.results)
    end
-   setmetatable(future, { __call = future.get })
-   return future
+
+   setmetatable(fut, { __call = function(self, ...) return self:get(...) end })
+   return fut
 end
 
 
@@ -222,8 +219,14 @@ function async.addthread(fn)
    local ch = lanes.linda()
 
    lanes.gen("*", function()
-      -- FIXME PCALL TEST
-      awake_future(ch, "done", fn())
+      local results
+      local ok, err = pcall(function()
+         results = pack(true, fn())
+      end)
+      if not ok then
+         results = pack(false, err)
+      end
+      awake_future(ch, "done", unpack(results, 1, results.n))
    end)()
 
    return new_future(ch, "done")
@@ -233,17 +236,18 @@ end
 
 --- Runs a function in its own thread, and waits for the results.
 -- This will block the current thread, but will not block other Copas threads.
+-- Returns like pcall: true + results on success, false + errmsg on error.
 -- @tparam function fn the function to execute async
--- @return the original functions return values
+-- @return true + the function's return values, or false + errmsg
 -- @usage -- assuming a function returning a value or nil+error, normally called like this;
 -- --
 -- --   local result, err = fn()
 -- --
 -- -- Can be called non-blocking like this:
 --
--- local result, err = async.run(fn)
+-- local ok, result, err = async.run(fn)
 -- -- or even shorter;
--- local result, err = async(fn)
+-- local ok, result, err = async(fn)
 function async.run(fn)
    return async.addthread(fn):get()
 end
@@ -258,7 +262,7 @@ end
 -- without blocking other coroutines (in other words, it internally runs `get()`
 -- in its `future`).
 -- @tparam string command The command to pass to `os.execute` in the async thread
--- @return the same as `os.execute` (can differ by platform and Lua version)
+-- @return like pcall: true + os.execute results on success, false + errmsg on error
 function async.os_execute(command)
    return async.run(function()
       return os.execute(command)
@@ -294,15 +298,15 @@ function async.io_popen(command, mode)
       while true do
          local _, fd_cmd = ch:receive("fd_cmd")
          if fd_cmd == "close" then
-            awake_future(ch, "result", fd:close())
+            awake_future(ch, "result", true, fd:close())
             break
          end
          if fd_cmd == nil then
             -- on the C-side of things passing nil is not the same as not
             -- passing anything
-            awake_future(ch, "result", fd[op](fd))
+            awake_future(ch, "result", true, fd[op](fd))
          else
-            awake_future(ch, "result", fd[op](fd, fd_cmd))
+            awake_future(ch, "result", true, fd[op](fd, fd_cmd))
          end
       end
       fd:close()
@@ -315,7 +319,7 @@ function async.io_popen(command, mode)
          end
          local ok = ch:send("fd_cmd", arg)
          if ok == true then
-            return new_future(ch, "result")()
+            return select(2, new_future(ch, "result"):get())
          end
       end
    end
@@ -324,7 +328,7 @@ function async.io_popen(command, mode)
       close = function()
          local ok = ch:send("fd_cmd", "close")
          if ok == true then
-            return new_future(ch, "result")()
+            return select(2, new_future(ch, "result"):get())
          end
       end,
       flush = function()
@@ -351,5 +355,8 @@ end
 return setmetatable(async, {
    __call = function(self, ...)
       return async.run(...)
-   end
+   end,
+   __index = function(_, k)
+      error("unknown field 'async." .. tostring(k) .. "'", 2)
+   end,
 })


### PR DESCRIPTION
- get() now returns pcall-style: true+results on success, false+errmsg on error
- try() now returns 3-state: PENDING(false)/SUCCESS(true)/ERROR('error') with results
- Replace assert-on-concurrent-access with copas.semaphore; multiple coroutines can now call get() concurrently and all are released when the result arrives
- Wrap fn() in pcall in the Lanes thread so task errors are captured and returned via get()/try() instead of being silently lost
- Add SUCCESS, PENDING, ERROR constants to the module (matching copas.future)
- Add module __index guard that errors on unknown field names (typo protection)
- Update io_popen internals: prepend true ok-flag in awake_future calls, strip it with select(2,...) on the consumer side
- Replace deprecated copas.sleep(-1) with copas.pauseforever()